### PR TITLE
Make the API URL configurable so that git2pdf works for GitHub Enterprise instances

### DIFF
--- a/bin/git2pdf
+++ b/bin/git2pdf
@@ -8,6 +8,7 @@ class Git2PdfBash < Thor
   option :repos, :default => "", aliases: :r
   option :user, aliases: :u
   option :password, aliases: :p, :default=>nil
+  option :api, aliases: :a
   option :organisation, aliases: :o
 
   def gen(repositories="")
@@ -17,6 +18,9 @@ class Git2PdfBash < Thor
     end
     puts "Creating a PDF of GitHub issues for repos: #{repos.join(', ')}"
     puts "Using organisation #{options[:organisation]}" if options[:organisation]
+    if ! options[:api].empty?
+	    puts "Using API #{options[:api]}"
+    end
     pass = options[:password]
     if options[:password] == "password" or options[:password].nil? or options[:password].strip.length == 0
       #option[:password] = Password.get("GitHub Password:")
@@ -25,7 +29,7 @@ class Git2PdfBash < Thor
       pass = pass.strip.gsub(/\n/,'')
     end
 
-    g = Git2Pdf.new repos: repos, basic_auth: [options[:user],pass], org: options[:organisation], user: options[:user]
+    g = Git2Pdf.new repos: repos, basic_auth: [options[:user],pass], org: options[:organisation], user: options[:user], api: options[:api]
     done = g.execute
     puts "\n#{done} cards output to issues.pdf"
   end

--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -5,11 +5,13 @@ require 'json'
 class Git2Pdf
   attr_accessor :repos
   attr_accessor :basic_auth
+  attr_accessor :api
 
   def initialize(options={})
     @repos = options[:repos] || []
     @basic_auth = options[:basic_auth] || nil
     @org = options[:org] || nil
+    @api = options[:api] || "https://api.github.com"
   end
 
   def execute
@@ -23,10 +25,10 @@ class Git2Pdf
       #json = `curl -u#{auth} https://api.github.com/repos/pocketworks/repo/issues?per_page=100 | jq '.[] | {state: .state, milestone: .milestone.title, created_at: .created_at, title: .title, number: .number, labels: [.labels[].name]}'`
       json = ""
       if @org
-        json = open("https://api.github.com/repos/#{@org}/#{repo}/issues?per_page=200&state=open", :http_basic_authentication => basic_auth).read
+        json = open("#{@api}/repos/#{@org}/#{repo}/issues?per_page=200&state=open", :http_basic_authentication => basic_auth).read
       else
         # for stuff like bob/stuff
-        json = open("https://api.github.com/repos/#{repo}/issues?per_page=200&state=open", :http_basic_authentication => basic_auth).read
+        json = open("#{@api}/repos/#{repo}/issues?per_page=200&state=open", :http_basic_authentication => basic_auth).read
       end
 
       hash = JSON.parse(json)


### PR DESCRIPTION
Tested with our internal GHE instance. Using the parameter

`... -a http://ghe.local/api/v3 ...`
