### PR TITLE
Quiet labels

### DIFF
--- a/bin/git2pdf
+++ b/bin/git2pdf
@@ -12,6 +12,7 @@ class Git2PdfBash < Thor
   option :organisation, aliases: :o
   option :labels, aliases: :l
   option :from_number, aliases: :f
+  option :quiet_labels, aliases: :q
 
   def gen(repositories="")
     repos = repositories.split(',').collect { |r| r.strip }
@@ -31,7 +32,7 @@ class Git2PdfBash < Thor
       pass = pass.strip.gsub(/\n/,'')
     end
 
-    g = Git2Pdf.new repos: repos, basic_auth: [options[:user],pass], org: options[:organisation], user: options[:user], api: options[:api], labels: options[:labels], from_number: options[:from_number]
+    g = Git2Pdf.new repos: repos, basic_auth: [options[:user],pass], org: options[:organisation], user: options[:user], api: options[:api], labels: options[:labels], from_number: options[:from_number], quiet_labels: options[:quiet_labels]
     done = g.execute
     puts "\n#{done} cards output to issues.pdf"
   end

--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -14,6 +14,7 @@ class Git2Pdf
     @api = options[:api] || 'https://api.github.com'
     @labels = "&labels=#{options[:labels]}" || ''
     @from_number = options[:from_number] || nil
+    @silent_labels = ['ready', 'in progress', 'in test', 'done']
   end
 
   def execute
@@ -41,7 +42,7 @@ class Git2Pdf
             next
           end
         end
-        labels = val["labels"].collect { |l| l["name"].upcase }.join(', ')
+        labels = val["labels"].reject { |l| @silent_labels.include?(l["name"]) }.collect { |l| l["name"].upcase }.join(', ')
         type = ""
         type = "BUG" if labels =~ /bug/i #not billable
         type = "FEATURE" if labels =~ /feature/i #billable

--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -14,7 +14,7 @@ class Git2Pdf
     @api = options[:api] || 'https://api.github.com'
     @labels = "&labels=#{options[:labels]}" || ''
     @from_number = options[:from_number] || nil
-    @quiet_labels = ['ready', 'in progress', 'in test', 'done']
+    @quiet_labels = options[:quiet_labels] || []
   end
 
   def execute

--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -14,7 +14,7 @@ class Git2Pdf
     @api = options[:api] || 'https://api.github.com'
     @labels = "&labels=#{options[:labels]}" || ''
     @from_number = options[:from_number] || nil
-    @silent_labels = ['ready', 'in progress', 'in test', 'done']
+    @quiet_labels = ['ready', 'in progress', 'in test', 'done']
   end
 
   def execute
@@ -42,7 +42,10 @@ class Git2Pdf
             next
           end
         end
-        labels = val["labels"].reject { |l| @silent_labels.include?(l["name"]) }.collect { |l| l["name"].upcase }.join(', ')
+        labels = val["labels"].reject { |l| @quiet_labels.include?(l["name"]) }
+                              .collect { |l| l["name"].upcase }
+                              .join(', ')
+
         type = ""
         type = "BUG" if labels =~ /bug/i #not billable
         type = "FEATURE" if labels =~ /feature/i #billable

--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -123,22 +123,22 @@ class Git2Pdf
           #text_box fields["due"] || "", :at=>[120,20], :width=>60, :overflow=>:shrink_to_fit
           y_offset = y_offset + 20
         end
-        
+
         fill_color "EEEEEE"
-        fill_color "D0021B" if issue[:type] == "BUG"            
-        fill_color "1D8FCE" if issue[:type] == "TASK"            
+        fill_color "D0021B" if issue[:type] == "BUG"
+        fill_color "1D8FCE" if issue[:type] == "TASK"
         fill_color "FBF937" if issue[:type] == "FEATURE"
         fill_color "F5B383" if issue[:type] == "AMEND"
         fill_color "FBF937" if issue[:type] == "ENHANCEMENT"
 
         if issue[:type] and issue[:type] != ""
-          fill{rectangle([0,220], margin-10, 220)}          
+          fill{rectangle([0,220], margin-10, 220)}
         else
-          fill{rectangle([0,220], margin-10, 220)}          
+          fill{rectangle([0,220], margin-10, 220)}
         end
-        
+
         fill_color(0,0,0,100)
-        
+
         # if issue[:type] and issue[:type] != ""
 #           y_offset = y_offset - 20
 #           # Type
@@ -158,8 +158,6 @@ class Git2Pdf
         text_box issue[:labels].length == 0 ? "NO LABELS!" : issue[:labels], :at => [margin, 20], :width => 220-margin, :overflow => :shrink_to_fit
         #text_box fields[:due] || "", :at=>[120,20], :width=>60, :overflow=>:shrink_to_fit
         #end
-
-        
 
         #if col == 1
         #  row = row + 1


### PR DESCRIPTION
I just found you gem and needed a minor change for it to be useful in my project. I am creating this PR in case you would find it useful too. Basicly I didn't want the labels that tools like Waffle add to issues in order to track the progress to show up on the printable card.

```
# Usage:
git2pdf gen -u user -r repo -q 'ready, in progress, done'
```