### PR TITLE
Include :labels attribute in Git2Pdf class.

### DIFF
--- a/lib/git2pdf.rb
+++ b/lib/git2pdf.rb
@@ -6,6 +6,7 @@ class Git2Pdf
   attr_accessor :repos
   attr_accessor :basic_auth
   attr_accessor :api
+  attr_accessor :labels
 
   def initialize(options={})
     @repos = options[:repos] || []


### PR DESCRIPTION
Labels attribute was missing from the class preventing that functionality from executing properly.